### PR TITLE
Add code

### DIFF
--- a/.ts
+++ b/.ts
@@ -1,9 +1,5 @@
-import assert from "assert"
 import shellEscape from "shell-escape"
 import ShellResponse from "./shell-response.ts"
-
-// Can only be run in Deno
-assert("Deno" in globalThis)
 
 export default function execsh(strings: TemplateStringsArray, ...inserts: Array<unknown>) {
     const command = inserts.flatMap((insert, index) => [strings[index], shellEscape(String(insert))]).concat([strings.at(-1)]).join(" ")

--- a/.ts
+++ b/.ts
@@ -1,0 +1,27 @@
+import assert from "assert"
+import shellEscape from "shell-escape"
+import ShellResponse from "./shell-response.ts"
+
+// Can only be run in Deno
+assert("Deno" in globalThis)
+
+export default function execsh(strings: TemplateStringsArray, ...inserts: Array<unknown>) {
+    const command = inserts.flatMap((insert, index) => [strings[index], shellEscape(String(insert))]).concat([strings.at(-1)]).join(" ")
+
+    const childProcess = Deno.run({
+        cmd: [shell, "-c", prefix + command],
+        stdout: "piped",
+        stderr: "piped",
+        // Foward cwd and env variables
+        cwd: Deno.cwd(),
+        env: Deno.env.toObject(),
+    })
+    const response = new ShellResponse(childProcess)
+    response.command = command
+    return response
+}
+
+// Only currently supported shell
+const shell = `/bin/sh`
+// Apply this to every command for better error handling
+const prefix = `set -euo pipefail; `

--- a/deps.importmap
+++ b/deps.importmap
@@ -1,6 +1,5 @@
 {
-    "imports": {
-        "assert": "https://esm.sh/assert@2.0.0",
-        "shell-escape": "https://deno.land/x/shell_escape@1.0.0/single-argument.ts"
-    }
+	"imports": {
+		"shell-escape": "https://deno.land/x/shell_escape@1.0.0/single-argument.ts"
+	}
 }

--- a/deps.importmap
+++ b/deps.importmap
@@ -1,0 +1,6 @@
+{
+    "imports": {
+        "assert": "https://esm.sh/assert@2.0.0",
+        "shell-escape": "https://deno.land/x/shell_escape@1.0.0/single-argument.ts"
+    }
+}

--- a/shell-response.ts
+++ b/shell-response.ts
@@ -1,0 +1,67 @@
+export { ShellResponse as default }
+export type { ShellResponseOptions }
+
+class ShellResponse implements Body {
+    readonly command: string
+    readonly headers: Headers
+    readonly stdout: ReadableStream<Uint8Array>
+    readonly stderr: ReadableStream<Uint8Array>
+    #childProcess: Deno.Process
+    bodyUsed = false
+    constructor(childProcess: Deno.Process, { signal }: ShellResponseOptions = {}) {
+        this.command = ""
+        this.#childProcess = childProcess
+        this.headers = new Headers({
+            pid: this.#childProcess.pid,
+            rid: this.#childProcess.rid,
+        })
+        this.stdout = this.#childProcess.stdout.readable
+        this.stderr = this.#childProcess.stderr.readable
+
+        signal?.addEventListener("abort", (event) => {
+            if (!event.isTrusted) {
+                return
+            }
+
+            this.#childProcess.kill("SIGINT")
+            this.#childProcess.close()
+        })
+        childProcess.status().then(() => {
+            this.bodyUsed = true
+        })
+    }
+
+    get body() {
+        return this.stdout
+    }
+    async arrayBuffer() {
+        return await this.#childProcess.output()
+    }
+    async blob() {
+        return new Blob([await this.arrayBuffer()])
+    }
+    async text() {
+        return new TextDecoder().decode(await this.arrayBuffer())
+    }
+    async json() {
+        const text = await this.text()
+        return JSON.parse(text)
+    }
+    async formData(): Promise<FormData> {
+        throw new Error(`Not implemented`)
+    }
+
+    get status() {
+        return this.#childProcess.status().then(($) => $.code)
+    }
+    get ok() {
+        return this.#childProcess.status().then(($) => $.success)
+    }
+    get statusText() {
+        return this.#childProcess.stderrOutput()
+    }
+}
+
+interface ShellResponseOptions {
+    signal?: AbortSignal
+}


### PR DESCRIPTION
Creates the initial class and layout of the module to fit the `Response`-like design of the API

Todo
- [x] Replace image and example code with non-`await` versions since this returns _sync_, not async like `fetch()`
- [ ] Add tests
- [ ] Add build script for NPM